### PR TITLE
rix_publicURL_redirect404

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -41,8 +41,7 @@ module.exports = {
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
     proxyTable: {
-      "/api": commonProxy,
-      "/public": commonProxy
+      "/api": commonProxy
     },
     // CSS Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README

--- a/src/pages/oj/router/routes.js
+++ b/src/pages/oj/router/routes.js
@@ -290,6 +290,10 @@ export default [
   },
   {
     path: '*',
+    redirect: '404'
+  },
+  {
+    path: '/404',
     meta: {title: '404'},
     component: NotFound
   }


### PR DESCRIPTION
url 경로에 /public 입력 시 경로가 제대로 지정되어있지 않은 오류