### PR TITLE
GEN-975 feat(eval-ui): '실패만 재평가' 버튼 + 셀 실패 표시 + 툴팁 에러 미리보기

### DIFF
--- a/src/pages/oj/views/lecture/eval/EvalApi.js
+++ b/src/pages/oj/views/lecture/eval/EvalApi.js
@@ -43,8 +43,11 @@ export default {
   getEvalStatus: (contestId) => unwrap(evalAxios.get(`/contests/${contestId}/eval-status`)),
   getQueue: () => unwrap(evalAxios.get('/queue')),
   getJob: (jobId) => unwrap(evalAxios.get(`/jobs/${jobId}`)),
-  triggerEval: (contestId, force) =>
-    unwrap(evalAxios.post(`/contests/${contestId}/qualitative-eval`, { force: !!force })),
+  triggerEval: (contestId, force, mode) => {
+    // mode 가 명시되면 우선 (pending|all|failed). 미지정 시 force boolean 으로 폴백.
+    const body = mode ? { mode } : { force: !!force }
+    return unwrap(evalAxios.post(`/contests/${contestId}/qualitative-eval`, body))
+  },
   cancelJob: (jobId) => unwrap(evalAxios.post(`/jobs/${jobId}/cancel`)),
   contestExportUrl: (contestId, fmt, opts) =>
     `/api/eval/contests/${contestId}/score_export?${exportQuery(fmt, opts)}`,

--- a/src/pages/oj/views/lecture/eval/EvalControls.vue
+++ b/src/pages/oj/views/lecture/eval/EvalControls.vue
@@ -20,7 +20,7 @@
       <span v-if="status" class="status-text" :title="status">{{ status }}</span>
     </div>
     <Button :disabled="primaryDisabled"
-            @click="trigger(false)"
+            @click="trigger('pending')"
             type="primary"
             size="small"
             class="btn primary-btn">
@@ -28,10 +28,17 @@
       {{ primaryLabel }}
     </Button>
     <Button :disabled="forceDisabled"
-            @click="trigger(true)"
+            @click="trigger('all')"
             size="small"
             class="btn">
       {{ $t('m.EvalReevaluate') }}
+    </Button>
+    <Button :disabled="failedOnlyDisabled"
+            @click="trigger('failed')"
+            size="small"
+            class="btn"
+            title="이전 평가에서 LLM 응답 처리에 실패한 항목만 다시 시도합니다">
+      실패만 재평가
     </Button>
     <Poptip v-if="isActive"
             confirm
@@ -71,6 +78,7 @@
       isActive () { return !!this.activeJob },
       primaryDisabled () { return this.triggering || this.isActive },
       forceDisabled () { return this.triggering || this.isActive },
+      failedOnlyDisabled () { return this.triggering || this.isActive },
       primaryLabel () {
         if (this.triggering) return this.$t('m.EvalRequesting')
         if (this.isActive) return this.$t('m.EvalInProgress')
@@ -108,10 +116,14 @@
       }
     },
     methods: {
-      trigger (force) {
+      trigger (modeOrForce) {
+        // boolean(legacy: false/true) → 'pending'/'all', string('pending'|'all'|'failed') 그대로 사용.
+        const mode = typeof modeOrForce === 'boolean'
+          ? (modeOrForce ? 'all' : 'pending')
+          : modeOrForce
         this.triggering = true
         this.status = '요청 중…'
-        EvalApi.triggerEval(this.contestId, force)
+        EvalApi.triggerEval(this.contestId, null, mode)
           .then(r => {
             this.status = r.joined_existing
               ? `기존 작업 합류 (대기 ${r.queue_position || 0})`

--- a/src/pages/oj/views/lecture/eval/Scoreboard.vue
+++ b/src/pages/oj/views/lecture/eval/Scoreboard.vue
@@ -134,15 +134,24 @@
           .finally(() => { this.loading = false })
       },
       cellClass (cell) {
-        if (!cell || !cell.testcase) return 'empty'
-        // Backend JudgeStatus: 0=AC, -1=WA, -2=CE, -3 미사용,
-        // 1=TLE, 2=RTLE, 3=MLE, 4=RE, 5=SE, 6=PENDING, 7=JUDGING, 8=PA
-        const r = cell.testcase.result
-        if (r === 0) return 'ac'
-        if (r === 8) return 'pa'
-        if (r === -2) return 'ce'
-        if (r === 6 || r === 7) return 'pending'
-        return 'wa'
+        const classes = []
+        if (!cell || !cell.testcase) {
+          classes.push('empty')
+        } else {
+          // Backend JudgeStatus: 0=AC, -1=WA, -2=CE, -3 미사용,
+          // 1=TLE, 2=RTLE, 3=MLE, 4=RE, 5=SE, 6=PENDING, 7=JUDGING, 8=PA
+          const r = cell.testcase.result
+          if (r === 0) classes.push('ac')
+          else if (r === 8) classes.push('pa')
+          else if (r === -2) classes.push('ce')
+          else if (r === 6 || r === 7) classes.push('pending')
+          else classes.push('wa')
+        }
+        // 정성평가/AI 사용 평가가 실패로 기록된 셀은 좌상단 빨강 점으로 표시.
+        if (cell && cell.qualitative && cell.qualitative.has_error) {
+          classes.push('eval-fail')
+        }
+        return classes
       },
       resultKo (label) {
         const map = {
@@ -161,14 +170,31 @@
         return map[label] || label
       },
       resultTooltip (cell) {
-        if (!cell || !cell.testcase) return '미제출'
+        if (!cell || !cell.testcase) {
+          // 미제출이라도 정성평가 실패 정보가 있다면 우선 노출
+          if (cell && cell.qualitative && cell.qualitative.has_error) {
+            return this._evalErrorLines(cell.qualitative).join('\n') || '미제출'
+          }
+          return '미제출'
+        }
         const r = cell.testcase
         const ko = this.resultKo(r.result_label) + ' (' + r.result_label + ')'
         const parts = [ko]
         if (r.score !== undefined && r.score !== null) parts.push(`점수: ${r.score}`)
         if (r.language) parts.push(`언어: ${r.language}`)
         if (r.time_cost_ms !== undefined && r.time_cost_ms !== null) parts.push(`시간: ${r.time_cost_ms}ms`)
+        if (cell.qualitative && cell.qualitative.has_error) {
+          parts.push('') // 빈 줄 구분
+          parts.push(...this._evalErrorLines(cell.qualitative))
+        }
         return parts.join('\n')
+      },
+      _evalErrorLines (qual) {
+        const lines = []
+        if (qual.qual_error) lines.push(`정성평가 실패: ${qual.qual_error}`)
+        if (qual.ai_error) lines.push(`AI 사용 평가 실패: ${qual.ai_error}`)
+        if (lines.length === 0 && qual.has_error) lines.push('평가 실패 — 자세한 메시지는 셀을 클릭해 확인')
+        return lines
       },
       aiClass (score) {
         if (score >= 70) return 'ai-high'
@@ -317,6 +343,20 @@
         &.wa { background: rgba(237, 64, 20, 0.14); }
         &.ce { background: rgba(150, 150, 150, 0.16); }
         &.pending { background: rgba(45, 140, 240, 0.10); }
+        // 정성/AI 평가 실패 표시 — 좌상단 빨강 점. 기존 결과 배경 위에 overlay 라 가독성 영향 적음.
+        &.eval-fail::before {
+          content: '';
+          position: absolute;
+          top: 3px;
+          left: 3px;
+          width: 7px;
+          height: 7px;
+          border-radius: 50%;
+          background: #ed4014;
+          box-shadow: 0 0 0 1px #fff;
+          pointer-events: none;
+          z-index: 1;
+        }
         &.selected {
           box-shadow: inset 0 0 0 3px var(--text-hover-color);
           z-index: 1;


### PR DESCRIPTION
trigger 한 교수/조교/관리자가 강의 페이지에서 '어느 문제가 평가 실패인지'
즉시 알 수 있게 보강:

- EvalApi.triggerEval(contestId, force, mode?) 시그니처 확장 — mode 가 주어지면 body 에 우선 사용, 미지정 시 force 로 폴백 (legacy 호환).
- EvalControls.vue: '실패만 재평가' 세 번째 버튼 추가. trigger 메서드가 boolean(legacy) 와 string('pending'|'all'|'failed') 둘 다 수용.
- Scoreboard.vue: · cellClass 가 배열 반환으로 바뀌어 기존 ac/pa/wa/ce/pending 클래스와 eval-fail 가 공존 가능. has_error 인 셀은 좌상단 빨강 점 표시. · resultTooltip 에 qual_error / ai_error preview 라인 prepend — hover 시 별도 화면 이동 없이 실패 사유 미리보기.

대상: 강의 권한 보유자 (_require_lecture_perm). 학생 UI 는 이번 변경 없음.